### PR TITLE
Feature: Allow opening site in new tab to serve as data refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Dinger Poker
 
-This site lists a number of stats pages (i.e. reports) from Dinger Poker games. Each report is a different query (a particular year, all time, type of game, etc.)
+This site lists stats pages (i.e. reports) from Dinger Poker games. Each report is a different query (a particular year, all time, type of game, etc.)
 
-## Quick Start
+New reports can be uploaded as CSV files directly in the GitHub repository (in the `data` folder).
 
-**Add a new report** to the site:
+## Add a new report: Quick Version
 
 1. Add a CSV file to the `data` folder.
-2. Add an entry in the `reports.json` file with a filename that matches the CSV file you added. The reports will appear on the site the same order as the entries in the file.
+2. Add an entry in the `reports.json` file with a filename that matches the CSV file you added.
 
-That's it! The new report should appear on the site.
+That's it! The new report should appear on the site. It will appear on the site the same order as the entries in the file.
 
-## Details on adding a new report 
+## Add a new report: Detailed Version
+
+1. Add a CSV file to the `data` folder.
 
 ### Adding the CSV file
 
@@ -32,6 +34,8 @@ We expect a CSV file that uses only the column names below. We can use some or a
 - `Total Cost`
 - `Total Take`
 - `Total Winnings`
+
+2. Add an entry in the `reports.json` file with a filename that matches the CSV file you added.
 
 ### Adding an entry to `reports.json`
 
@@ -74,3 +78,7 @@ If you want to refresh the data from a report, just replace its CSV file in the 
 ### Delete a report
 
 Just remove its entry in `reports.json` and remove its CSV file.
+
+## Stale Data
+
+Let's say you just uploaded a new report. It's possible, if you have your browser open to the site while you upload the report, that you will not see the uploaded data. If this happens, just close the tab with the site and open a new one. 

--- a/main.js
+++ b/main.js
@@ -107,8 +107,9 @@ async function checkAndUpdateIfNecessary() {
   const lastVisitTimestamp = localStorage.getItem('lastVisitTimestamp');
   const lastVisitDate = lastVisitTimestamp ? new Date(lastVisitTimestamp) : null;
 
+  // TODO: Testing => I'm not absolutely sure this will allow the localStorage data to be refreshed if the commit to the repo happens on the same day. Need to try to make a commit to the data folder and see if I start a new session that  I'm in shows as fetching new data.
   if (!lastVisitDate || latestCommitTimestamp > lastVisitDate) {
-    console.log('Updating data by reading CSV files from GitHub...');
+    console.log('Updating data by reading CSV files from GitHub - either no lastVisitDate or the latestCommit is later than the lastVisitDate...');
     localStorage.clear();
     await loadReports();
     await setData();

--- a/main.js
+++ b/main.js
@@ -78,8 +78,9 @@ async function getLatestCommitTimeStamp() {
     return new Date(latestCommitTimestamp);
   } else {
     try {
-      console.log('Fetching latest commit timestamp from GitHub...');
-      const response = await fetch(`https://api.github.com/repos/mcqwertywhat/dinger-poker/commits/main`);
+      console.log('Fetching timestamp for the latest commit to the `data` folder from GitHub...');
+      // fetch only the latest commit (it *should* be the latest, according to GPT) from the main branch, for the data folder, with a limit of 1
+      const response = await fetch(`https://api.github.com/repos/mcqwertywhat/dinger-poker/commits/main?path=data&per_page=1`);
       const data = await response.json();    
       latestCommitTimestamp = new Date(data.commit.committer.date);
       return latestCommitTimestamp;

--- a/main.js
+++ b/main.js
@@ -58,9 +58,6 @@ async function loadReports() {
       }
     }
 
-    // Use the data (assign it to a variable or process it as needed)
-    console.log('Reports:', reports);
-
     // Now you can work with the `reports` object as needed
     // TODO: really? assign as global variable like this?
     // For example, assign it to a global variable if necessary

--- a/main.js
+++ b/main.js
@@ -116,8 +116,6 @@ async function checkAndUpdateIfNecessary() {
 }
 
 async function setData() {
-  const hardcodedVersion = 1; // Example: Hardcoded version number
-
   // Loop through each report
   for (let key in reports) {
     let report = reports[key];
@@ -126,33 +124,10 @@ async function setData() {
     if (cachedData) {
       // Data is available in localStorage
       let parsedData = JSON.parse(cachedData);
-
-      // Check if the cached version matches the hardcoded version
-      if (parsedData.version === hardcodedVersion) {
-        // Use cached data
-        report.headers = parsedData.headers;
-        report.data = parsedData.data;
-      } else {
-        // Cached version does not match, fetch new data
-        let data = await fetchCSV(`data/${report.filename}`);
-        headers = data
-          .trim()
-          .split("\n")[0]
-          .split(",")
-          .map((header) => header.trim());
-        // TODO: parseCSV seems to return only the data, not the headers; it seems like it should return both in an array for what i need
-        data = parseCSV(data);
-        report.headers = headers;
-        report.data = data;
-
-        // Update and store new data in localStorage with version number
-        localStorage.setItem(`${key}`, JSON.stringify({
-          version: hardcodedVersion,
-          headers: report.headers,
-          data: report.data
-        }));
-      }
+      report.headers = parsedData.headers;
+      report.data = parsedData.data;
     } else {
+      console.log(`Fetching report ${key} data from CSV...`)
       // Data is not available in localStorage, fetch it
       let data = await fetchCSV(`data/${report.filename}`);
       headers = data
@@ -167,7 +142,6 @@ async function setData() {
 
       // Store new data in localStorage with version number
       localStorage.setItem(`${key}`, JSON.stringify({
-        version: hardcodedVersion,
         headers: report.headers,
         data: report.data
       }));
@@ -185,7 +159,6 @@ async function setData() {
     })
     .filter((column) => column !== undefined);
 }
-
 
 function createHeaderRow() {
   const headerRow = document.getElementById("pColumns");


### PR DESCRIPTION
Use caching in `sessionStorage` of the latest commit from GitHub to ensure that we get the latest commit at the start of each session.