### PR TITLE
Performance: Lazy Loading

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@
 // TODO: should requestedReportID be set as global variable in some other way?
 const requestedReportID = new URLSearchParams(window.location.search).get("id");
 let reports;
+let mData;
+let mColumns;
 
 const validColumns = [
   { Key: "_Index", Name: "#" },
@@ -25,7 +27,8 @@ async function initializePage() {
   await loadReports();
   processQueryparams();
   await checkAndUpdateIfNecessary();
-  await loadReportData(requestedReportID);
+  const requestedReport = await loadReportData(requestedReportID);
+  setCurrentReport(requestedReport);
   createHeaderRow();
   updateReportTitle();
   createTableHeaderLinks();
@@ -188,16 +191,19 @@ async function loadReportData(key) {
     }));
   }
 
-// TODO: this needs to be set elsewhere outside setReportData, maybe in a function called setCurrentReport
-mData = report.data;
-const validHeaderNames = validColumns.map((column) => column.Name);
-mColumns = report.headers
-  .map((headerName) => {
-    if (validHeaderNames.includes(headerName)) {
-      return validColumns.find((column) => column.Name === headerName);
-    }
-  })
-  .filter((column) => column !== undefined);
+  return report;
+}
+
+function setCurrentReport(report) {
+  mData = report.data;
+  const validHeaderNames = validColumns.map((column) => column.Name);
+  mColumns = report.headers
+    .map((headerName) => {
+      if (validHeaderNames.includes(headerName)) {
+        return validColumns.find((column) => column.Name === headerName);
+      }
+    })
+    .filter((column) => column !== undefined);
 }
 
 function createHeaderRow() {

--- a/main.js
+++ b/main.js
@@ -130,6 +130,7 @@ async function checkAndUpdateIfNecessary() {
 async function cacheAllReportsData() {
   // this should run in the background and fetch all the data from the CSVs and store it in localStorage
   // it should only run if the data is not already in localStorage on the initial load of the page, and store an firstLoad session value to prevent it from running again
+  // we know this isn't being called unnecessarily because we checked it with a setTimeout of 10 seconds in testing; we could see that reports were not loaded ahead of time
   for (let key in reports) {
     if (reports[key].headers.length > 0 && reports[key].data.length > 0) {
       console.log(`${reports[key].title} is already loaded in memory!`)

--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ async function initializePage() {
   await loadReports();
   processQueryparams();
   await checkAndUpdateIfNecessary();
-  const requestedReport = await loadReportData(requestedReportID);
+  const requestedReport = await loadAndReturnReport(requestedReportID);
   // awaiting setCurrentReport because mColumns has to be set before creating the header row
   await setCurrentReport(requestedReport);
   createHeaderRow();
@@ -122,7 +122,7 @@ async function checkAndUpdateIfNecessary() {
     console.log('Clearing local storage...either no lastVisitDate or the latestCommit is later than the lastVisitDate');
     localStorage.clear();
     await loadReports();
-    await loadReportData(requestedReportID);
+    await loadAndReturnReport(requestedReportID);
     localStorage.setItem('lastVisitTimestamp', new Date().toISOString());
   }
 }
@@ -136,11 +136,11 @@ async function cacheAllReportsData() {
       console.log(`${reports[key].title} is already loaded in memory!`)
       continue;
     }
-    loadReportData(key);
+    loadAndReturnReport(key);
   }
 }
 
-async function loadReportData(key) {
+async function loadAndReturnReport(key) {
   let report = reports[key];
   let cachedReport = localStorage.getItem(`${key}`);
 

--- a/main.js
+++ b/main.js
@@ -81,7 +81,7 @@ async function getLatestCommitTimeStamp() {
   } else {
     try {
       console.log('Fetching timestamp for the latest commit to the `data` folder from GitHub...');
-      // fetch only the latest commit (it *should* be the latest, according to GPT) from the main branch, for the data folder, with a limit of 1
+      // fetch only the latest commit (`per_page=1` should be the latest, according to GPT) from the main branch, for the data folder
       const response = await fetch(`https://api.github.com/repos/mcqwertywhat/dinger-poker/commits/main?path=data&per_page=1`);
       const data = await response.json();    
       latestCommitTimestamp = new Date(data.commit.committer.date);
@@ -100,10 +100,8 @@ async function checkAndUpdateIfNecessary() {
     console.error('Could not get latest commit timestamp.');
     return;
   }
-  // we set the latest commit timestamp in session storage so we don't have to fetch it again this session
-  // but we do want to check for updates on each session; 
-  // this was decided as an alternative to having a button where the user refreshed their data manually
-  // now instead, the user should just close the tab and reopen to get the latest data
+  // we use session storage for this one value, but local storage for others because we want to check for updates on each session
+  // this also allows a user to just close the tab and reopen to get the latest data
   sessionStorage.setItem('latestCommitTimestamp', latestCommitTimestamp.toISOString());
 
   const lastVisitTimestamp = localStorage.getItem('lastVisitTimestamp');

--- a/main.js
+++ b/main.js
@@ -147,7 +147,7 @@ async function loadAndReturnReport(key) {
   if (cachedReport) {
     report = JSON.parse(cachedReport);
   } else {
-    console.log(`Fetching report "${report.title}" data from CSV...`)
+    console.log(`Fetching "${report.title}" report data from CSV...`)
     // Data is not available in localStorage, fetch it
     let data = await fetchCSV(`data/${report.filename}`);
     let headers = data

--- a/main.js
+++ b/main.js
@@ -134,32 +134,7 @@ async function cacheAllReportsData() {
       console.log(`${reports[key].title} is already loaded in memory!`)
       continue;
     }
-    let report = reports[key];
-    let cachedData = localStorage.getItem(`${key}`);
-
-    if (cachedData) {
-      // Data is available in localStorage
-      report = JSON.parse(cachedData);
-    } else {
-      console.log(`Fetching report "${report.title}" data from CSV...`)
-      // Data is not available in localStorage, fetch it
-      let data = await fetchCSV(`data/${report.filename}`);
-      headers = data
-        .trim()
-        .split("\n")[0]
-        .split(",")
-        .map((header) => header.trim());
-      // TODO: parseCSV seems to return only the data, not the headers; it seems like it should return both in an array for what i need
-      data = parseCSV(data);
-      report.headers = headers;
-      report.data = data;
-
-      // Store new data in localStorage
-      localStorage.setItem(`${key}`, JSON.stringify({
-        headers: report.headers,
-        data: report.data
-      }));
-    }
+    loadReportData(key);
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -28,7 +28,8 @@ async function initializePage() {
   processQueryparams();
   await checkAndUpdateIfNecessary();
   const requestedReport = await loadReportData(requestedReportID);
-  setCurrentReport(requestedReport);
+  // awaiting setCurrentReport because mColumns has to be set before creating the header row
+  await setCurrentReport(requestedReport);
   createHeaderRow();
   updateReportTitle();
   createTableHeaderLinks();
@@ -169,7 +170,8 @@ async function loadReportData(key) {
   return report;
 }
 
-function setCurrentReport(report) {
+async function setCurrentReport(report) {
+  // async because mData and mColumns need to be set before other things happen
   mData = report.data;
   const validHeaderNames = validColumns.map((column) => column.Name);
   mColumns = report.headers


### PR DESCRIPTION
Change how data is cached and loaded so that we only load the first report before drawing the page and then cache other reports in the background afterward.