### PR TITLE
Feature: Allow columns names other than default from Tournament Director

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,18 +13,21 @@
     
   <body>
 
-    <div class="outer-table-container">
-      <div class="table-container">
+    <div class="align-center">
+      <div class="infoTable">
+        <div id="tHeader" class="tableHeader">
+          <div class="eventname">Dinger Poker Stats
+            <span>
+              <select id="report-select" class="eventname">
+                <!-- Options will be populated dynamically -->
+              </select>
+            </span>
+            <span id="info-icon">&#9432;<span id="info-text"></span></span>
+          </div>
+          
+        </div>
+
         <table id="pTable" cellspacing="0" class="statsTable">
-          <thead id="tHeader" class="tableHeader">
-            <tr>
-              <th id="table-header-controls" class="eventname">
-                Dinger Poker Stats
-                <select id="report-select" class="eventname"></select>
-                <span id="info-icon">&#9432;<span id="info-text"></span></span>          
-              </th>
-            </tr>
-          </thead>
           <tbody id="pBody">
             <tr id="pColumns">
             </tr>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <table id="pTable" cellspacing="0" class="statsTable">
           <thead id="tHeader" class="tableHeader">
             <tr>
-              <th colspan="100" class="eventname">
+              <th id="table-header-controls" class="eventname">
                 Dinger Poker Stats
                 <select id="report-select" class="eventname"></select>
                 <span id="info-icon">&#9432;<span id="info-text"></span></span>          

--- a/index.html
+++ b/index.html
@@ -13,21 +13,18 @@
     
   <body>
 
-    <div class="align-center">
-      <div class="infoTable">
-        <div id="tHeader" class="tableHeader">
-          <div class="eventname">Dinger Poker Stats
-            <span>
-              <select id="report-select" class="eventname">
-                <!-- Options will be populated dynamically -->
-              </select>
-            </span>
-            <span id="info-icon">&#9432;<span id="info-text"></span></span>
-          </div>
-          
-        </div>
-
+    <div class="outer-table-container">
+      <div class="table-container">
         <table id="pTable" cellspacing="0" class="statsTable">
+          <thead id="tHeader" class="tableHeader">
+            <tr>
+              <th colspan="100" class="eventname">
+                Dinger Poker Stats
+                <select id="report-select" class="eventname"></select>
+                <span id="info-icon">&#9432;<span id="info-text"></span></span>          
+              </th>
+            </tr>
+          </thead>
           <tbody id="pBody">
             <tr id="pColumns">
             </tr>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Dinger Poker Stats</title>
     <link rel="stylesheet" href="styles.css">
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ const validColumns = [
   { Key: "First", Name: "1st" },
   { Key: "Second", Name: "2nd" },
   { Key: "Third", Name: "3rd" },
-  { Key: "AveragePlaced", Name: "Average Placed", DisplayName: "Wins Prize %" },
+  { Key: "AveragePlaced", Name: "Average Placed", DisplayName: "Wins Prize Avg" },
   { Key: "OnTheBubble", Name: "Bubble" },
   { Key: "AverageHits", Name: "Average Hits", DisplayName: "Avg Hits" },
 ];

--- a/main.js
+++ b/main.js
@@ -52,12 +52,12 @@ function populateInfoIcon(report) {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-    weekday: 'short',
+    weekday: 'long',
     hour: 'numeric',
     minute: '2-digit',
   };
   const localDateString = date.toLocaleString(undefined, options);
-  document.getElementById("info-text").textContent = `"${report.title}" was last updated on ${localDateString}`;
+  document.getElementById("info-text").innerHTML = `<strong>${report.title}</strong> last updated on<br/> ${localDateString}`;
 }
 
 function addEventListenerForInfoIcon() {  

--- a/main.js
+++ b/main.js
@@ -14,11 +14,11 @@ const validColumns = [
   { Key: "TotalWinnings", Name: "Total Winnings", DisplayName: "Winnings" },
   { Key: "TotalCost", Name: "Total Cost", DisplayName: "Cost" },
   { Key: "TotalTake", Name: "Total Take", DisplayName: "Take" },
-  { Key: "TimesPlaced", Name: "Times Placed", DisplayName: "Podiums" },
+  { Key: "TimesPlaced", Name: "Times Placed", DisplayName: "Prizes Awarded" },
   { Key: "First", Name: "1st" },
   { Key: "Second", Name: "2nd" },
   { Key: "Third", Name: "3rd" },
-  { Key: "AveragePlaced", Name: "Average Placed", DisplayName: "Avg Placed" },
+  { Key: "AveragePlaced", Name: "Average Placed", DisplayName: "Wins Prize %" },
   { Key: "OnTheBubble", Name: "Bubble" },
   { Key: "AverageHits", Name: "Average Hits", DisplayName: "Avg Hits" },
 ];

--- a/main.js
+++ b/main.js
@@ -227,8 +227,6 @@ async function setCurrentReport(report) {
 
 function createHeaderRow() {
   const headerRow = document.getElementById("pColumns");
-  // set the column span based on the number of columns
-  document.getElementById("table-header-controls").colSpan = mColumns.length;
 
   mColumns.forEach((column) => {
     // TODO: this is a th, but originally was a td... check CSS to see if anything messes up because of it

--- a/main.js
+++ b/main.js
@@ -227,6 +227,8 @@ async function setCurrentReport(report) {
 
 function createHeaderRow() {
   const headerRow = document.getElementById("pColumns");
+  // set the column span based on the number of columns
+  document.getElementById("table-header-controls").colSpan = mColumns.length;
 
   mColumns.forEach((column) => {
     // TODO: this is a th, but originally was a td... check CSS to see if anything messes up because of it

--- a/main.js
+++ b/main.js
@@ -261,6 +261,9 @@ function createTableRows() {
       const td = document.createElement("td");
       td.textContent = column.Text;
       td.className = `statsColumn align-${column.Align}`;
+      if (column.FixedClasses) {
+        td.className += ` ${column.FixedClasses}`;
+      }
       tr.appendChild(td);
     });
 
@@ -290,11 +293,18 @@ function parseCSV(csvText) {
       const numericColumn = validColumns.find((column) => column.Name === key);
       const formattedText = numericColumn.Transform ? numericColumn.Transform(numericValue) : value;
       
+      let fixedClasses = null;
+      if (key === "#") {
+        fixedClasses = 'fixed-column fixed-column-0';
+      } else if (key === "Name") {
+        fixedClasses = 'fixed-column fixed-column-1';
+      }
       return {
         Text: formattedText,
         HTML: formattedText,
         SortValue: isNaN(numericValue) ? value.toLowerCase() : numericValue,
         Align: !isNaN(numericValue) ? "right" : "left",
+        FixedClasses: fixedClasses
       };
     });
 

--- a/main.js
+++ b/main.js
@@ -6,19 +6,19 @@ let mData;
 let mColumns;
 
 const validColumns = [
-  { Key: "_Index", Name: "#" },
-  { Key: "Name", Name: "Name" },
-  { Key: "Buyins", Name: "Buy-ins" },
+  { Key: "_Index", Name: "#", DisplayName: "#"},
+  { Key: "Name", Name: "Name", DisplayName: "Name" },
+  { Key: "Buyins", Name: "Buy-ins", DisplayName: "Games" },
   { Key: "RebuysCount", Name: "Rebuys" },
   { Key: "Hits", Name: "Hits" },
-  { Key: "TotalWinnings", Name: "Total Winnings", DisplayName: "Winnings" },
+  { Key: "TotalWinnings", Name: "Total Winnings", DisplayName: "Won" },
   { Key: "TotalCost", Name: "Total Cost", DisplayName: "Cost" },
   { Key: "TotalTake", Name: "Total Take", DisplayName: "Take" },
-  { Key: "TimesPlaced", Name: "Times Placed", DisplayName: "Prizes Awarded" },
+  { Key: "TimesPlaced", Name: "Times Placed", DisplayName: "Payouts" },
   { Key: "First", Name: "1st" },
   { Key: "Second", Name: "2nd" },
   { Key: "Third", Name: "3rd" },
-  { Key: "AveragePlaced", Name: "Average Placed", DisplayName: "Wins Prize Avg" },
+  { Key: "AveragePlaced", Name: "Average Placed", DisplayName: "Payout %" },
   { Key: "OnTheBubble", Name: "Bubble" },
   { Key: "AverageHits", Name: "Average Hits", DisplayName: "Avg Hits" },
 ];

--- a/main.js
+++ b/main.js
@@ -11,16 +11,16 @@ const validColumns = [
   { Key: "Buyins", Name: "Buy-ins" },
   { Key: "RebuysCount", Name: "Rebuys" },
   { Key: "Hits", Name: "Hits" },
-  { Key: "TotalWinnings", Name: "Total Winnings" },
-  { Key: "TotalCost", Name: "Total Cost" },
-  { Key: "TotalTake", Name: "Total Take" },
-  { Key: "TimesPlaced", Name: "Times Placed" },
+  { Key: "TotalWinnings", Name: "Total Winnings", DisplayName: "Winnings" },
+  { Key: "TotalCost", Name: "Total Cost", DisplayName: "Cost" },
+  { Key: "TotalTake", Name: "Total Take", DisplayName: "Take" },
+  { Key: "TimesPlaced", Name: "Times Placed", DisplayName: "Podiums" },
   { Key: "First", Name: "1st" },
   { Key: "Second", Name: "2nd" },
   { Key: "Third", Name: "3rd" },
-  { Key: "AveragePlaced", Name: "Average Placed" },
+  { Key: "AveragePlaced", Name: "Average Placed", DisplayName: "Avg Placed" },
   { Key: "OnTheBubble", Name: "Bubble" },
-  { Key: "AverageHits", Name: "Average Hits" },
+  { Key: "AverageHits", Name: "Average Hits", DisplayName: "Avg Hits" },
 ];
 
 async function initializePage() {
@@ -232,7 +232,8 @@ function createHeaderRow() {
     // TODO: this is a th, but originally was a td... check CSS to see if anything messes up because of it
     const th = document.createElement("th");
     th.className = `statsColumn statsColumnHeader align-${column.Align}`;
-    th.textContent = column.Name;
+    const displayName = column.DisplayName ? column.DisplayName : column.Name;
+    th.textContent = displayName;
     headerRow.appendChild(th);
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -114,10 +114,10 @@ body {
 
 @media screen and (max-width: 600px) {
 
-  /* TODO: no background (blue area) showing on any edge */
   /* TODO: keep columns names and event name stuck to top of browser on mobile */
   /* TODO: move info icon somewhere else */
   /* TODO: give columns a mobile display name */
+  /* TODO: investigate align-undefined being set as a class */
 
   body {
     margin: 0;

--- a/styles.css
+++ b/styles.css
@@ -86,7 +86,7 @@ body {
 #info-icon {
   display: inline-block;
   color:rgb(221, 221, 221);
-  font-size: .75em;
+  font-size: 1.5rem;
   cursor: pointer;
 }
 
@@ -95,11 +95,10 @@ body {
   position: absolute;
   background-color: #d3d3d3;
   margin-left: 3px;
-  margin-top: 2px;
   color: #000;
   border-radius: 3px;
-  padding: 5px;
-  font-size: .6em;
+  padding: 5px 10px;
+  font-size: .9rem;
   font-weight: lighter;
   z-index: 1;
 }

--- a/styles.css
+++ b/styles.css
@@ -111,3 +111,90 @@ body {
   padding-right: 10px;
   padding-left: 5px;
 }
+
+@media screen and (max-width: 600px) {
+
+  /* TODO: no background (blue area) showing on any edge */
+  /* TODO: fix padding on table to make more compact on mobile */
+  
+  .infoTable {
+    max-width: 100%;
+    overflow-x: scroll;
+    font-size: .75rem;
+  }
+
+  .tableHeader {
+    left: 0;
+    min-height: 62px;
+  }
+
+  .eventname {
+    font-size: .9rem;
+  }
+
+  #info-icon {
+    font-size: 1rem;
+  }
+
+  #info-text {
+    right: 10px;
+    top: 44px;
+    margin-left: 3px;
+    border-radius: 3px;
+    padding: 5px 10px;
+    font-size: .6rem;
+    font-weight: lighter;
+    z-index: 1;
+  }
+
+  .fixed-column {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+  }
+  
+  .fixed-column-0 {
+    left: 0;
+  }
+  
+  .fixed-column-1 {
+    left: 36px; /* Adjust based on the width of your first column */
+  }
+  
+  #pColumns .fixed-column {
+    z-index: 2; /* Ensure headers are above the rest of the cells */
+  }
+
+  /* # (rank) cells note that "even" actually means "odd rank number" */
+  tr.even > :nth-child(1) {
+    background-color: #eee;
+  }
+  
+  tr.odd > :nth-child(1) {
+    background-color: #fff;
+  }
+  
+  /* player name cells note that "even" actually means "odd rank number" */
+  tr.even > :nth-child(2) {
+    background-color: #eee;
+    border-right: 1px solid #e3e3e3;
+  }
+  
+  tr.odd > :nth-child(2) {
+    background-color: #fff;
+    border-right: 1px solid #e3e3e3;
+  }
+
+  #pColumns > :nth-child(1) {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+  }
+
+  #pColumns > :nth-child(2) {
+    position: sticky;
+    left: 36px;
+    z-index: 2;
+    border-right: 1px solid #e3e3e3;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -57,7 +57,7 @@ body {
 }
 
 .statsTable {
-  padding: 8px;
+  padding: 0px; /* do not make padding more than 0 or sticky header names */
   background-color: #fff;
   color: #000;
   border-radius: 6px;

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 html {
   font-family: Arial;
-  font-size: 10pt;
+  font-size: 12pt;
 }
 
 a {
@@ -72,7 +72,7 @@ body {
 }
 
 .statsColumn {
-  padding: 5px 5px;
+  padding: 1rem;
   white-space: nowrap;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -115,21 +115,33 @@ body {
 @media screen and (max-width: 600px) {
 
   /* TODO: no background (blue area) showing on any edge */
-  /* TODO: fix padding on table to make more compact on mobile */
+  /* TODO: keep columns names and event name stuck to top of browser on mobile */
+  /* TODO: move info icon somewhere else */
+  /* TODO: give columns a mobile display name */
+
+  body {
+    margin: 0;
+  }
   
+  /* controls all table text  */
   .infoTable {
     max-width: 100%;
     overflow-x: scroll;
     font-size: .75rem;
   }
 
-  .tableHeader {
-    left: 0;
-    min-height: 62px;
+  .statsColumn {
+    padding: .5rem;
   }
 
+  .tableHeader {
+    left: 0;
+    min-height: 61px;
+  }
+
+  /* controls size of page heading and select control; set to .9rem to deal with iPhone SE screen */
   .eventname {
-    font-size: .9rem;
+    font-size: 0.9rem;
   }
 
   #info-icon {
@@ -144,7 +156,7 @@ body {
     padding: 5px 10px;
     font-size: .6rem;
     font-weight: lighter;
-    z-index: 1;
+    z-index: 2;
   }
 
   .fixed-column {
@@ -158,7 +170,7 @@ body {
   }
   
   .fixed-column-1 {
-    left: 36px; /* Adjust based on the width of your first column */
+    left: 26px; /* Adjust based on the width of your first column */
   }
   
   #pColumns .fixed-column {
@@ -193,7 +205,7 @@ body {
 
   #pColumns > :nth-child(2) {
     position: sticky;
-    left: 36px;
+    left: 26px;
     z-index: 2;
     border-right: 1px solid #e3e3e3;
   }

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,11 @@ body {
   background-color: #5f7a96;
 }
 
-.infoTable {
+.outer-table-container {
+  text-align: center;
+}
+
+.table-container {
   border: 2px solid #000;
   border-radius: 6px;
   font-size: 1.0rem;
@@ -67,7 +71,7 @@ body {
 .statsColumnHeader {
   font-weight: bold;
   position: sticky;
-  top: 64px; /* TODO: this value is adjusted to position it just under .tableHeader for desktop */
+  top: 54px; /* TODO: this value is adjusted to position it just under .tableHeader for desktop */
   background-color: #fff;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -28,11 +28,7 @@ body {
   background-color: #5f7a96;
 }
 
-.outer-table-container {
-  text-align: center;
-}
-
-.table-container {
+.infoTable {
   border: 2px solid #000;
   border-radius: 6px;
   font-size: 1.0rem;
@@ -71,7 +67,7 @@ body {
 .statsColumnHeader {
   font-weight: bold;
   position: sticky;
-  top: 54px; /* TODO: this value is adjusted to position it just under .tableHeader for desktop */
+  top: 64px; /* TODO: this value is adjusted to position it just under .tableHeader for desktop */
   background-color: #fff;
 }
 


### PR DESCRIPTION
- Allow a `DisplayName` for each column that is used if provided, instead of the Tournament Director column names
- Make slight improvements to UI:
  - make default font size bigger
  - add padding in cells to make it easier to read
  - make leftmost columns stick to left side to easily see which player has which stat