### PR TITLE
UI Improvements: Remove Page Refreshes and Table Resize

### DIFF
--- a/js/dataUtils.js
+++ b/js/dataUtils.js
@@ -121,6 +121,8 @@ export async function loadAndReturnReport(key) {
     localStorage.setItem(`${key}`, JSON.stringify(report));
   }
 
+  await setHeadersForReport(report)
+
   return report;
 }
 
@@ -137,7 +139,7 @@ function orderHeaders(headers) {
   return orderedHeaders;
 }
 
-export async function setCurrentReport(report) {
+export async function setHeadersForReport(report) {
   // async because mData and mColumns need to be set before other things happen
   const validHeaderNames = validColumns.map((column) => column.name);
   const mColumns = report.headers

--- a/js/dataUtils.js
+++ b/js/dataUtils.js
@@ -121,7 +121,7 @@ export async function loadAndReturnReport(key) {
     localStorage.setItem(`${key}`, JSON.stringify(report));
   }
 
-  await setHeadersForReport(report)
+  setHeadersForReport(report)
 
   return report;
 }
@@ -139,7 +139,7 @@ function orderHeaders(headers) {
   return orderedHeaders;
 }
 
-export async function setHeadersForReport(report) {
+export function setHeadersForReport(report) {
   // async because mData and mColumns need to be set before other things happen
   const validHeaderNames = validColumns.map((column) => column.name);
   const mColumns = report.headers

--- a/js/domUtils.js
+++ b/js/domUtils.js
@@ -2,7 +2,7 @@ export function createHeaderRow(mColumns) {
   const headerRow = document.getElementById("p-columns");
   mColumns.forEach((column) => {
     const th = document.createElement("th");
-    th.className = `stats-col stats-col-header align-${column.align}`;
+    th.className = `stats-col stats-col-header align-${column.align} min-width-${column.minWidth ? column.minWidth : "3"}`;
     const displayName = column.displayName ? column.displayName : column.name;
     th.textContent = displayName;
     headerRow.appendChild(th);

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -29,19 +29,19 @@ export function addEventListenerForReportSelect() {
     document.getElementById("p-columns").innerHTML = "";
     const tBody = document.getElementById("p-table-body")
     
+    // clear table of current data
     while (tBody.childNodes.length > 2) {
       tBody.removeChild(tBody.lastChild)
     }
-
+    
     const requestedReport = await loadAndReturnReport(requestedReportID);
-    const currentReport = await setCurrentReport(requestedReport);
-    const mData = currentReport.data;
-    const mColumns = currentReport.headers;
-    window.mData = mData;
-    window.mColumns = mColumns;
+    await setCurrentReport(requestedReport);
+
+    window.mData = requestedReport.data;
+    window.mColumns = requestedReport.headers;
 
     createHeaderRow(mColumns);
-    populateInfoIcon(currentReport);
+    populateInfoIcon(requestedReport);
     createTableRows(mData);
 
     // TODO: the init method probably does too much stuff after the page has already been loaded. need something lighter weight that does not reinstall event handlers for clicking columns

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -41,11 +41,11 @@ export function addEventListenerForReportSelect() {
     window.mColumns = mColumns;
 
     createHeaderRow(mColumns);
-    populateDropdown(requestedReportID);
     populateInfoIcon(currentReport);
     addEventListenerForReportSelect();
-    addEventListenerForInfoIcon();
     createTableRows(mData);
+
+    // TODO: need to prevent sort from constantly reversing; may need to pass more variables here or declare new ones
     TDSort.init("p-table", "p-columns", mColumns, mData);
   });
 }

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -45,7 +45,7 @@ export function addEventListenerForReportSelect() {
     addEventListenerForReportSelect();
     createTableRows(mData);
 
-    // TODO: need to prevent sort from constantly reversing; may need to pass more variables here or declare new ones
+    // TODO: the init method probably does too much stuff after the page has already been loaded. need something lighter weight that does not reinstall event handlers for clicking columns
     TDSort.init("p-table", "p-columns", mColumns, mData);
   });
 }

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -1,3 +1,17 @@
+import {
+  setCurrentReport,
+  loadAndReturnReport,
+} from "./dataUtils.js";
+
+import {
+  createHeaderRow,
+  createTableRows,
+  populateDropdown,
+  populateInfoIcon,
+} from "./domUtils.js";
+
+import { TDSort } from "./sortingMethods.js";
+
 export function addEventListenerForInfoIcon() {
   document.getElementById("info-icon").addEventListener("click", () => {
     const infoText = document.getElementById("info-text");
@@ -11,8 +25,27 @@ export function addEventListenerForInfoIcon() {
 }
 
 export function addEventListenerForReportSelect() {
-  document.getElementById("report-select").addEventListener("change", () => {
-    const requestedReportID = document.getElementById("report-select").value;
-    window.location.href = `index.html?id=${requestedReportID}`;
+  document.getElementById("report-select").addEventListener("change", async (e) => {
+    const requestedReportID = e.target.value
+    document.getElementById("p-columns").innerHTML = "";
+    const tBody = document.getElementById("p-table-body")
+    while (tBody.childNodes.length > 2) {
+      tBody.removeChild(tBody.lastChild)
+    }
+
+    const requestedReport = await loadAndReturnReport(requestedReportID);
+    const currentReport = await setCurrentReport(requestedReport);
+    const mData = currentReport.data;
+    const mColumns = currentReport.headers;
+    window.mData = mData;
+    window.mColumns = mColumns;
+
+    createHeaderRow(mColumns);
+    populateDropdown(requestedReportID);
+    populateInfoIcon(currentReport);
+    addEventListenerForReportSelect();
+    addEventListenerForInfoIcon();
+    createTableRows(mData);
+    TDSort.init("p-table", "p-columns", mColumns, mData);
   });
 }

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -6,7 +6,6 @@ import {
 import {
   createHeaderRow,
   createTableRows,
-  populateDropdown,
   populateInfoIcon,
 } from "./domUtils.js";
 
@@ -29,6 +28,7 @@ export function addEventListenerForReportSelect() {
     const requestedReportID = e.target.value
     document.getElementById("p-columns").innerHTML = "";
     const tBody = document.getElementById("p-table-body")
+    
     while (tBody.childNodes.length > 2) {
       tBody.removeChild(tBody.lastChild)
     }
@@ -42,7 +42,6 @@ export function addEventListenerForReportSelect() {
 
     createHeaderRow(mColumns);
     populateInfoIcon(currentReport);
-    addEventListenerForReportSelect();
     createTableRows(mData);
 
     // TODO: the init method probably does too much stuff after the page has already been loaded. need something lighter weight that does not reinstall event handlers for clicking columns

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -1,5 +1,4 @@
 import {
-  setCurrentReport,
   loadAndReturnReport,
 } from "./dataUtils.js";
 
@@ -35,7 +34,6 @@ export function addEventListenerForReportSelect() {
     }
     
     const requestedReport = await loadAndReturnReport(requestedReportID);
-    await setCurrentReport(requestedReport);
 
     window.mData = requestedReport.data;
     window.mColumns = requestedReport.headers;

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,5 @@
 import {
   loadReports,
-  setCurrentReport,
   loadAndReturnReport,
   cacheAllReportsData,
   updateLocalStorageIfNecessary,
@@ -28,15 +27,14 @@ async function initializePage() {
   const requestedReportID = getRequestedReportID();
   await updateLocalStorageIfNecessary(requestedReportID);
   const requestedReport = await loadAndReturnReport(requestedReportID);
-  const currentReport = await setCurrentReport(requestedReport);
-  const mData = currentReport.data;
-  const mColumns = currentReport.headers;
+  const mData = requestedReport.data;
+  const mColumns = requestedReport.headers;
   window.mData = mData;
   window.mColumns = mColumns;
 
   createHeaderRow(mColumns);
   populateDropdown(requestedReportID);
-  populateInfoIcon(currentReport);
+  populateInfoIcon(requestedReport);
   addEventListenerForReportSelect();
   addEventListenerForInfoIcon();
   createTableRows(mData);

--- a/js/main.js
+++ b/js/main.js
@@ -53,7 +53,6 @@ function getRequestedReportID() {
   let requestedReportID = new URLSearchParams(window.location.search).get("id");
   if (!requestedReportID || !Object.keys(reports).includes(requestedReportID)) {
     requestedReportID = Object.keys(reports).find(key => reports[key].default) || Object.keys(reports)[0];
-    window.location.href = `index.html?id=${requestedReportID}`;
   }
   return requestedReportID
 }

--- a/js/main.js
+++ b/js/main.js
@@ -40,7 +40,7 @@ async function initializePage() {
   addEventListenerForReportSelect();
   addEventListenerForInfoIcon();
   createTableRows(mData);
-  TDSort.init("p-table", "p-columns");
+  TDSort.init("p-table", "p-columns", mColumns, mData);
   if (sessionStorage.getItem("firstLoad") === null) {
     // load other report data in background
     cacheAllReportsData();

--- a/js/sortingMethods.js
+++ b/js/sortingMethods.js
@@ -31,6 +31,7 @@ export const TDSort = (function () {
             mColumns[i].key != "_PlayerImage" &&
             mColumns[i].key != "_HitmanImage"
           ) {
+            // this installs an onclick handler for each row 
             theRow.cells[i].onclick = getSortFn(i);
             theRow.cells[i].style.cursor = "pointer";
           }

--- a/js/sortingMethods.js
+++ b/js/sortingMethods.js
@@ -13,7 +13,9 @@ export const TDSort = (function () {
     var mIndexCol = 0;
   
     // initialize the page
-    function init(inTableID, inHeaderRowID) {
+    function init(inTableID, inHeaderRowID, mColumns, mData) {
+      // always reset sort when initializing the table for a new report
+      sortedHighToLow = false
       mTableID = inTableID;
       mHeaderRowID = inHeaderRowID;
       // install an onClick handler for each column header

--- a/js/validColumns.js
+++ b/js/validColumns.js
@@ -17,6 +17,7 @@ export const validColumns =
       align: "left",
       defaultSort: "asc",
       bestScore: null,
+      minWidth: 12
     },
     {
       key: "Buyins",
@@ -42,6 +43,7 @@ export const validColumns =
       bestScore: "high",
       sortOnPageLoad: true,
       transform: transformMoney,
+      minWidth: 5
     },
     {
       key: "TotalCost",
@@ -51,6 +53,7 @@ export const validColumns =
       defaultSort: "desc",
       bestScore: null,
       transform: transformMoney,
+      minWidth: 5
     },
     {
       key: "TotalTake",
@@ -60,6 +63,7 @@ export const validColumns =
       defaultSort: "desc",
       bestScore: "high",
       transform: transformMoney,
+      minWidth: 5
     },
     {
       key: "TimesPlaced",

--- a/js/validColumns.js
+++ b/js/validColumns.js
@@ -5,7 +5,7 @@ export const validColumns =
     {
       key: "_Index",
       name: "#",
-      displayName: "#",
+      displayName: " ",
       align: "left",
       defaultSort: null,
       bestScore: null,

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,30 @@
 html {
   font-family: Georgia, 'Times New Roman', Times, serif;
-  font-size: 14pt;
+  font-size: 13pt;
 }
 
 body {
   background-color: #5f7a96;
+}
+
+/* most cols need a default width of 3 characters */
+#p-columns > th {
+  min-width: 3ch;
+}
+
+/* name col */
+#p-columns > :nth-child(2) {
+  min-width: 12ch;
+}
+
+/* money columns need 5 characters - '$' followed by up to 4 digits */
+#p-columns > :nth-child(5), #p-columns > :nth-child(6), #p-columns > :nth-child(7) {
+  min-width: 5ch;
+}
+
+/* places seem to need 2 chars at most */
+#p-columns > :nth-child(10), #p-columns > :nth-child(11), #p-columns > :nth-child(12) {
+  min-width: 2ch;
 }
 
 .table-container {

--- a/styles.css
+++ b/styles.css
@@ -7,24 +7,19 @@ body {
   background-color: #5f7a96;
 }
 
-/* most cols need a default width of 3 characters */
-#p-columns > th {
+/* most cols need a default width of 3 characters; this class is used by default on each th */
+.min-width-3 {
   min-width: 3ch;
 }
 
-/* name col */
-#p-columns > :nth-child(2) {
-  min-width: 12ch;
-}
-
 /* money columns need 5 characters - '$' followed by up to 4 digits */
-#p-columns > :nth-child(5), #p-columns > :nth-child(6), #p-columns > :nth-child(7) {
+.min-width-5 {
   min-width: 5ch;
 }
 
-/* places seem to need 2 chars at most */
-#p-columns > :nth-child(10), #p-columns > :nth-child(11), #p-columns > :nth-child(12) {
-  min-width: 2ch;
+/* longest name seems to be 12 */
+.min-width-12 {
+  min-width: 12ch;
 }
 
 .table-container {

--- a/styles.css
+++ b/styles.css
@@ -116,7 +116,7 @@ body {
 }
 
 .sort-name-col-arrow::after {
-  right: 18px;
+  right: 7ch;
 }
 
 .sort-col-desc::after {

--- a/styles.css
+++ b/styles.css
@@ -116,7 +116,7 @@ body {
 }
 
 .sort-name-col-arrow::after {
-  right: 7ch;
+  right: 7.5ch;
 }
 
 .sort-col-desc::after {


### PR DESCRIPTION
Instead of making a new request when selecting a new report, only redraw table with new data. Also, ensure that the table columns remain a fixed width so that the table does not appear to resize and column header names do not shift when a new report is selected.